### PR TITLE
[오타수정] layoutspec, flexbox 페이지 오타수정

### DIFF
--- a/newbie-guide/flex-box.md
+++ b/newbie-guide/flex-box.md
@@ -6,7 +6,7 @@ description: 기존 iOS개발자 및 Newbie들이 Texture를 접근할 때 가�
 
 ## Flex Grow & Shrink
 
-**flex-grow**란? 레이아웃의 **증가 너비 비율**을 지정합니다. 이와 반대로 f**lex-shrink**는 레이아웃의 **감소 너비 비율**을 지정합니다.
+**flex-grow**란? 레이아웃의 **증가 너비 비율**을 지정합니다. 이와 반대로 **flex-shrink**는 레이아웃의 **감소 너비 비율**을 지정합니다.
 
 둘 다 공간에 대해서 비율을 지정하는 프로퍼티이지만 다른 점은 
 
@@ -50,7 +50,7 @@ Texture를 사용하는 개발자들을 위해서 좀 더 친숙하게 Texture L
 
 ![](../.gitbook/assets/undefined.png)
 
-저희는 위의 사진과 같은 image view와 text view를 horizontal 하게 [stackLayout](https://texture-kr.gitbook.io/wiki/layout-api/layoutspecs#3-asstacklayoutspec)으로 배치 할껍니다. 
+저희는 위의 사진과 같은 image view와 text view를 horizontal 하게 [stackLayout](https://texture-kr.gitbook.io/wiki/layout-api/layoutspecs#3-asstacklayoutspec)으로 배치할 겁니다.
 
 이미지는 1.0 ratioLayout 으로 배치되어 있으며 [width](https://texture-kr.gitbook.io/wiki/layout-api/layout-element-properties#2-basic-layout-element-properties)값은 50pt로 지정했습니다. 
 

--- a/newbie-guide/layoutspec.md
+++ b/newbie-guide/layoutspec.md
@@ -98,7 +98,7 @@ _constraints관계는 top, bottom, left, right, leading, trailing 및 inset, mar
 
 **Autolayout을 코드**로 작성했을 경우는 Xib 및 Storyboard에 비해 모듈화하기도 쉽고 체계적으로 쓸 수는 있으나 변화요소에 대한 추가작업에 대해서는 여전히 UI 컴포넌트 간의 **constraints관계**를 파악해야합니다.
 
-하지만 **Texture Layout API**의 경우는 다른점이 다양한 **LayoutSpec**이라는 것이 제공됩니다. **선언적이고 명시적인 LayoutSpec**을 사용함으로서 자신 또는 다른 개발자입장에서 봤을 어떠한 형태로 **레이아웃**이 **설계**되었는지 **추론**하기 용이할 뿐더러, 새로운 컴포넌트를 추가하는데 있어서도 **영향을 받는 LayoutSpec에서 코드를 수정**하기면 되기 때문에 contraints관계 파악하는 거보다 상대적으로 빠르고 쉽습니다.
+하지만 **Texture Layout API**의 경우는 다른점이 다양한 **LayoutSpec**이라는 것이 제공됩니다. **선언적이고 명시적인 LayoutSpec**을 사용함으로서 자신 또는 다른 개발자입장에서 봤을 어떠한 형태로 **레이아웃**이 **설계**되었는지 **추론**하기 용이할 뿐더러, 새로운 컴포넌트를 추가하는데 있어서도 **영향을 받는 LayoutSpec에서 코드를 수정**하면 되기 때문에 contraints관계 파악하는 거보다 상대적으로 빠르고 쉽습니다.
 
 ![](../.gitbook/assets/2019-03-30-7.36.13.png)
 


### PR DESCRIPTION
**flex-box.md**
L.9 (이와 반대로 f**lex-shrink**는) -> (이와 반대로 **flex-shrink**)
f만 볼드처리 안되있는거 수정하였습니다.
L.53 (배치 할껍니다.) -> (배치할 겁니다.)
띄어쓰기 및 오타 수정하였습니다.

**layoutspec.md**
L.101 (**영향을 받는 LayoutSpec에서 코드를 수정**하기면) -> (**영향을 받는 LayoutSpec에서 코드를 수정**하면)
오타 수정하였습니다.