### PR TITLE
Nodes 오타 수정

### DIFF
--- a/nodes/asbuttonnode.md
+++ b/nodes/asbuttonnode.md
@@ -37,7 +37,7 @@ buttonNode.contentVerticalAlignment = .top
 buttonNode.contentHorizontalAlignment = .middle
 ```
 
-> 현재 LayoutSpecThatFits\(:\) 를 사용하지 않으면 이 프로퍼티가 정 작동하지 않습니다.
+> 현재 LayoutSpecThatFits\(:\) 를 사용하지 않으면 이 프로퍼티가 정상 작동하지 않습니다.
 
 ## tintColor 설정
 

--- a/nodes/ascontrolnode.md
+++ b/nodes/ascontrolnode.md
@@ -64,7 +64,7 @@ let node = ASControlNode()
 node.hitTestSlop = .init(top: -100.0, left: -100.0, bottom: -100.0, right: -100.0)
 ```
 
-#### 터치영역 줄이
+#### 터치영역 줄이기
 
 ```swift
 let node = ASControlNode()

--- a/nodes/asimagenode.md
+++ b/nodes/asimagenode.md
@@ -17,7 +17,7 @@ imageNode.contentMode = .scaleAspectFill
 
 이미지 모양에 영향을 주는 대부분의 작업들은 Main Thread 의 큰 리소스를 차지하고 있었습니다. 당연히 우리는 이러한 작업들을 Background Thread 로 옮기고 싶습니다.
 
-`imageNode` 에 `imageModificationBlock` 을 할당함으로써, 별도의 호출없이 `imageNode` 의 이미지들에 비동기적으로 일어나야 하는 transformation\(rounding, boder 넣기, 또는 패턴 overlay 등과 같은 이미지 효과\) 의 집합을 정의할 수 있습니다.
+`imageNode` 에 `imageModificationBlock` 을 할당함으로써, 별도의 호출없이 `imageNode` 의 이미지들에 비동기적으로 일어나야 하는 transformation\(rounding, border 넣기, 또는 패턴 overlay 등과 같은 이미지 효과\) 의 집합을 정의할 수 있습니다.
 
 이것에 대해 더 알고싶다면, [Image Modification Blocks](http://texturegroup.org/docs/image-modification-block.html) 를 참고하세요.
 


### PR DESCRIPTION
1. ASButtonNode
 - `정 작동하지 않습니다` -> `정상 동작하지 않습니다`
2. ASImageNode
 - `boder 넣기` -> `border 넣기`
 ```
as rounding, adding borders, or other pattern overlays,
 ``` 
3. ASControlNode 
 - `터치영역 줄이` -> `터치영역 줄이기`
---
한번에 수정을 해서 `PR` 했어야 했는데.. 문서 읽는게 간격이 있었네요.
다음에 오타수정이 있으면 챕터(?)단위로 PR하도록 하겠습니다. 🙏 