### PR TITLE
예제 코드 오류 수정

### DIFF
--- a/layout-api/layoutspecs.md
+++ b/layout-api/layoutspecs.md
@@ -417,7 +417,7 @@ horizontal 및 vertical 에 대한 정렬기준옵션입니다. **none, start, c
 override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
   let centerLayout = ASCenterLayoutSpec(
     centeringOptions: .XY,
-    sizingOptions: .minimumXY
+    sizingOptions: .minimumXY,
     child: self.childNode1
   )
 


### PR DESCRIPTION
`LayoutSpec/7. ASCenterLayoutSpec`의 예제중 파라미터 사이에 `,`가 없는 오류를 수정하였습니다!