### PR TITLE
예시 및 문서 수정

### DIFF
--- a/newbie-guide/layoutspec.md
+++ b/newbie-guide/layoutspec.md
@@ -307,12 +307,12 @@ Texture가 Auto-Layout으로 설계된 레이아웃보다 랜더링하는데 있
         alignItems: .stretch,
         children: [
           self.profileNode,
-          self.infoLayout
+          infoLayout
         ]
       )
 
     return ASInsetLayoutSpec(
-      insets: UIEdgeInsets,
+      insets: UIEdgeInsets.zero,
       child: profileWithInfoLayout
     )
   }

--- a/nodes/asnetworkimagenode.md
+++ b/nodes/asnetworkimagenode.md
@@ -1,19 +1,19 @@
 # ASNetworkImageNode
 
-`ASNetworkImageNode` 는 원격 서버에서 호스팅된 이미지를 보여주고 싶을 때 사용할 수 있다. `ASNetworkImageNode` 의 `.url`  프로퍼티에 적합한 URL 을 넣어주면 이미지는 비동기로 로드되고, 동시에 렌더링 될 것이다.
+`ASNetworkImageNode` 는 원격 서버에서 호스팅된 이미지를 보여주고 싶을 때 사용할 수 있습니다. `ASNetworkImageNode` 의 `.url`  프로퍼티에 적합한 URL을 넣어주면 이미지는 비동기로 로드되고, 동시에 렌더링 됩니다.
 
 ```swift
 let imageNode = ASNetworkImageNode()
 imageNode.url = URL(string: "https://someurl.com/image_uri")
 ```
 
-## NetworkImageNode 의 레이아웃 잡기
+## NetworkImageNode의 레이아웃 잡기
 
-`ASNetworkImageNode` 는 만들어 질 때 `intrinsic content size` 를 가지고 있지 않기 때문에, layout 을 명시적으로 설정해 주어야 한다.
+`ASNetworkImageNode` 는 만들어 질 때 `intrinsic content size` 를 가지고 있지 않기 때문에, layout을 명시적으로 설정해 주어야 합니다.
 
 #### _Option 1: .style.preferredSize_
 
-만약 이미지 노드의 프레임 크기를 표준 크기로 지정하려는 경우 `.style.preferredSize` 를 사용할 수 있다.
+만약 이미지 노드의 프레임 크기를 표준 크기로 지정하려는 경우 `.style.preferredSize` 를 사용할 수 있습니다.
 
 ```swift
 override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
@@ -25,7 +25,7 @@ override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec
 
 #### _Option 2: ASRatioLayoutSpec_
 
-이 곳은 `ASRatioLayoutSpec` 를 사용하기에 최적의 장소입니다. 당신은 이미지에 정적인 사이즈를 할당하는 대신, 비율을 할당할 수 있고, 이미지는 로딩을 마쳤을 때 해당 비율을 유지하면서 보여질 것이다.
+ASNetworkImageNode는 `ASRatioLayoutSpec` 를 사용하기에 최적의 장소입니다. 당신은 이미지에 정적인 사이즈를 할당하는 대신 비율을 할당할 수 있고, 이미지는 로딩을 마쳤을 때 해당 비율을 유지하면서 보여집니다.
 
 ```swift
 override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
@@ -38,31 +38,33 @@ override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec
 
 ## 이면
 
-> 만약 당신이 `PINRemoteImage` 와 `PINCache` 의존성을 포함하지 않는다면, progressive jpeg 지원을 받지 못하고, `ASImageCacheProtocol` 을 따르는 커스텀 캐시를 포함해야 한다.
+> 만약  `PINRemoteImage` 와 `PINCache` 의존성을 포함하지 않는다면, progressive jpeg 지원을 받지 못하고  `ASImageCacheProtocol` 을 따르는 커스텀 캐시를 포함해야 합니다.
 
 ### Progressive JPEG 지원
 
-`PINRemoteImage`를 포함한 덕분에 Network Image Node 는 이제 Progressive JPEG 이미지를 완전히 지원한다. 만약 서버가 Progressive JPEG 이미지를 제공한다면, 이미지들은 저화질로 빠르게 보여진 후에 더 많은 데이터가 로드되면 scale up 하게 된다.
+`PINRemoteImage`를 포함하면 Network Image Node는 이제 Progressive JPEG 이미지를 완벽하게 지원합니다. 만약 서버가 Progressive JPEG 이미지를 제공한다면, 이미지들은 저화질로 빠르게 보여진 후에 더 많은 데이터가 로드되면 scale up 하게 됩니다.
 
-progressive loading \(점진적 이미지 로딩\) 을 활성화 하려면 `shouldRenderProgressImages` 값을 `true`로 설정하세요.
+progressive loading \(점진적 이미지 로딩\) 을 활성화 하려면 `shouldRenderProgressImages` 값을 `true`로 설정해야 합니다.
 
 ```swift
 networkImageNode.shouldRenderProgressImages = true
 ```
 
-이 옵션은 하나의 이미지를 사용해 점진적으로 로드한다. 만약 서버가 일반적인 JPEG 포맷을 지원하고, 이미지의 여러 퀄리티 버전을 제공한다면, ASMultiplexImageNode 를 사용해보자.
+이 옵션은 하나의 이미지를 사용해 점진적으로 로드합니다. 서버가 일반적인 JPEG 포맷을 지원하고 이미지의 여러 퀄리티 버전을 제공할 때, ASMultiplexImageNode를 사용해보면 좋습니다.
 
 ## 자동 캐싱
 
-`ASNetworkImageNode` 는 네트워크 이미지들을 자동으로 캐시하기 위해 이제 `PINCache` 를 default 로 사용합니다.
+`ASNetworkImageNode` 는 네트워크 이미지들을 자동으로 캐시하기 위해 default 로  `PINCache` 를 사용합니다.
 
 ## GIF 지원
 
-`ASNetworkImageNode` 는 `PINRemoteImage` 의 베타 `PINAnimatedImage` 를 통해 GIF 를 지원합니다. 주의 하세요! 이러한 지원은 `shouldCacheImage` 가 `NO`로 설정되어 있지 않는 한 local 파일들에는 지원되지 않습니다.
+`ASNetworkImageNode` 는 `PINRemoteImage` 의 베타 `PINAnimatedImage` 를 통해 GIF를 지원합니다. 
+
+*주의 하세요!* 이러한 지원은 `shouldCacheImage` 가 `NO`로 설정되어 있지 않는 한 local 파일들에는 지원되지 않습니다.
 
 ## Image Downloader 에 URLSessionConfiguration 추가하기
 
-`ASNetworkImageNode` 는 기본적으로 이미지를 다운로드를 할 때 `ASPinRemoteImageDownloader` 를 사용한다. 만약 이미지 요청에 추가로 configuration 이 필요한 경우 아래의 코드로 대응 가능하다.
+`ASNetworkImageNode` 는 기본적으로 이미지를 다운로드를 할 때 `ASPinRemoteImageDownloader` 를 사용합니다. 만약 이미지 요청에 추가로 configuration이 필요한 경우 아래의 코드로 대응 가능합니다.
 
 ```swift
 var config = URLSessionConfiguration.ephemeral

--- a/nodes/astextnode.md
+++ b/nodes/astextnode.md
@@ -1,12 +1,12 @@
 # ASTextNode
 
-ASTextNode 는 Texture 의 기본 텍스트 노드로, 일반적으로 UILabel 을 사용할 때 언제든지 사용할 수 있다.  
-또 모든 Rich Text 를 지원하고, ASControlNode 의 서브 클래스로 titleLabel 만 사용해 UIButton을 만들 때 언제든지 사용할 수 있다.
+ASTextNode는 Texture의 기본 텍스트 노드로, 일반적으로 UILabel을 사용할 때 언제든지 사용할 수 있습니다.  
+또 모든 Rich Text를 지원하고, ASControlNode의 서브 클래스로 titleLabel 만 사용해 UIButton을 만들 때 언제든지 사용할 수 있습니다.
 
 ## 기본 사용법
 
-ASTextNode 의 인터페이스는 UILabel 을 사용했던 사람들 모두에게 익숙해야 한다.  
-다만, UILabel 과의 첫 번째 차이점은 ASTextNode 는 일반 String 대신 Attributed String 만을 사용한다는 것이다.
+UILabel을 사용했던 사람들에게 ASTextNode의 인터페이스는 익숙하게 느껴질 수 있습니다.  
+다만, UILabel과의 첫 번째 차이점은 ASTextNode는 일반 String 대신 Attributed String만을 사용한다는 것입니다.
 
 ```swift
 let attrs = [NSFontAttributeName: UIFont(name: "HelveticaNeue", size: 12.0)]
@@ -16,11 +16,11 @@ node = ASTextNode()
 node.attributedText = string
 ```
 
-보다시피, 기본 Text Node 를 만드려면 표준 생성자를 사용한 뒤 표시할 Attributed String 을 설정하기만 하면 된다.
+위 예시처럼, 기본 Text Node를 만들려면 표준 생성자를 사용한 뒤 표시할 Attributed String 을 설정하기만 하면 됩니다.
 
 ## Truncation
 
-TextNode 가 모든 텍스트를 표시할 수 없다면, 텍스트는 가능한 한 많이 표시되고 잘려진 부분은 Truncation String 으로 대체된다.
+TextNode가 모든 텍스트를 표시할 수 없다면, 텍스트는 가능한 한 많이 표시되고 잘려진 부분은 Truncation String으로 대체됩니다.
 
 ```swift
 textNode = ASTextNode()
@@ -28,17 +28,17 @@ textNode.attributedText = string
 textNode.truncationAttributedText = NSAttributedString(string: "¶¶¶")
 ```
 
-결과는 아래와 같다.
+결과는 아래와 같습니다.
 
 ![Truncation Example](../.gitbook/assets/image.png)
 
-기본적으로 Truncation String 은 '...' 이 되므로, 이 것만 필요하다면 따로 설정하지 않아도 된다.
+Truncation String은 디폴트로 '...' 이 되므로, 이 설정으로 충분하다면 따로 설정하지 않아도 됩니다.
 
 ## Link Attributes
 
-텍스트를 링크로 지정하고 싶다면, 먼저 TextNode 에 `string` 의 배열인 `linkAttributes` 배열을 set 해야 한다. 이것은 `attributed string` 에서 link 들의 키로 사용이 될 것이다.
+텍스트를 링크로 지정하고 싶다면, 먼저 TextNode에 `string` 의 배열인 `linkAttributes` 배열을 설정해야 합니다. 이 배열은 `attributed string` 에서 링크들의 key로 사용됩니다.
 
-그리고 나면, 너의 `string` 에 `attribute` 를 설정할 때, 이 key 들이 알맞은 NSURL을 가리키도록 할 수 있다.
+이렇게하면  `string` 에 `attribute` 를 설정할 때, 이 key들이 알맞은 NSURL을 가리키도록 할 수 있습니다.
 
 ```swift
 textNode.linkAttributeNames = [kLinkAttributeName]
@@ -56,16 +56,16 @@ textNode.attributedText = attributedString
 textNode.isUserInteractionEnabled = true
 ```
 
-위의 코드는 대시 스타일의 밑줄이 그어진 연회색 링크를 만들어낼 것이다!
+위의 코드를 통해 아래 그림과 같이 전체 문장 중 "placekitten.com" 부분에 점선 스타일의 밑줄이 그어진 회색 링크가 적용됩니다.
 
 ![Link Attributes Example](../.gitbook/assets/kittenlink.png)
 
-여기서 볼 수 있듯이, 이것은 attributed string 의 range 에 따라서, 여러가지 스타일을 각각의 링크에 적용하기에 편리하다.
+여기서 볼 수 있듯이, attributed string의 range에 따라서 여러가지 스타일을 각각의 링크에 적용하기에 편리합니다.
 
 ## ASTextNodeDelegate
 
-ASTextNodeDelegate 를 따르면 Class 가 TextNode 와 관련된 다양한 이벤트에 반응할 수 있다.  
-예를 들면, 아래 처럼 link 를 tap 하는 이벤트에 반응할 수 있다.
+ASTextNodeDelegate를 채택하면 해당 Class가 TextNode와 관련된 다양한 이벤트에 반응할 수 있습니다.
+예를 들면, 아래처럼 구현하면 link를 tap하는 이벤트에 반응할 수 있습니다.
 
 ```swift
 func textNode(_ textNode: ASTextNode, tappedLinkAttribute attribute: String, value: Any, at point: CGPoint, textRange: NSRange) {
@@ -76,7 +76,7 @@ func textNode(_ textNode: ASTextNode, tappedLinkAttribute attribute: String, val
 }
 ```
 
-이와 유사한 방법으로 LongPress 와 Highlighting 에 대해 다음과 같이 반응할 수 있다.
+또한 LongPress와 Highlighting에 대해 다음과 같이 반응할 수 있습니다.
 
 * textNode\(\_ , shouldHighlightLinkAttribute: value: point:\)
 * textNode\(\_ , shouldLongPressLinkAttribute: value: point:\)
@@ -84,9 +84,9 @@ func textNode(_ textNode: ASTextNode, tappedLinkAttribute attribute: String, val
 
 ## 잘못된 줄 간격과 최대 라인 수
 
-`NSParagraphStyle` 의 `lineSpacing` 을 사용하면 최대 라인 수를 가진 멀티라인 텍스트에서 문제가 발생할 수 있다.
+`NSParagraphStyle` 의 `lineSpacing` 을 사용하면 최대 라인 수를 가진 멀티라인 텍스트에서 문제가 발생할 수 있습니다.
 
-예를 들어 다음 코드를 참조하세요.
+예를 들면, 아래 코드의 경우 문제가 발생합니다.
 
 ```swift
 let someLongString = "..."
@@ -106,9 +106,9 @@ textNode.maximumNumberOfLines = 4
 textNode.attributedText = NSAttributedString(string: someLongString, attributes: attributes)
 ```
 
-`ASTextNode` 는 내부적으로 TextKit 을 사용하여 지정된 최대 라인 수를 산출하는 데 필요한 shrink 를 계산한다.
+`ASTextNode` 는 내부적으로 TextKit 을 사용하여 지정된 최대 라인 수를 산출하는 데 필요한 shrink를 계산합니다.
 
-하지만 위의 예시에서는 텍스트가 너무 많이 줄어들게 될 것이다. 4줄의 텍스트 대신에, 3줄의 텍스트와 하단의 이상한 간격이 나타날 것이다. 이 문제를 해결하려면 TextNode 에서 `truncationMode` 를 `.byTruncatingTail` 로 설정해야 한다.
+하지만 위의 예시에서는 텍스트가 너무 많이 줄어들게 됩니다. 4줄의 텍스트 대신에, 3줄의 텍스트와 하단의 이상한 간격이 나타날 것입니다. 이 문제를 해결하려면 TextNode 에서 `truncationMode` 를 `.byTruncatingTail` 로 설정해야 합니다.
 
 ```swift
 // ...


### PR DESCRIPTION
### 배경
- 예시 코드에 오류가 있거나 개선 여지가 있어 수정했어요.
- 어색한 번역체와 말투가 통일성이 없는 경우가 있어 이것을 수정하고 존댓말로 변경했어요.

### 수정사항
- layoutspec의 예시 코드 오류를 수정했어요.
- quick-example의 코드에서 Node를 Computed Property로 변경했어요.
- asnetworkimagenode를 존댓말로 변경하고 어색한 번역체를 수정했어요.
- astextnode를 존댓말로 변경하고 어색한 번역체를 수정했어요.
